### PR TITLE
`condition` in `seal` not to display as header

### DIFF
--- a/processing/customizations.xsl
+++ b/processing/customizations.xsl
@@ -117,6 +117,10 @@
         <xsl:apply-templates/>
     </xsl:template>
     
+    <xsl:template match="seal/condition">
+        <xsl:apply-templates/>
+    </xsl:template>
+    
     <xsl:template match="seal/p">
         <xsl:apply-templates/>
     </xsl:template>


### PR DESCRIPTION
#102
new rule to skip any display of `condition` within `seal`. This is consistent with current treatment of `decoNote` in `seal`.